### PR TITLE
FIX: User and Tags Questions Pagination

### DIFF
--- a/lib/actions/tag.actions.ts
+++ b/lib/actions/tag.actions.ts
@@ -1,8 +1,12 @@
-"use server"
+"use server";
 
 import User from "@/database/user.model";
 import { connectToDatabase } from "../mongoose";
-import { GetAllTagsParams, GetQuestionsByTagIdParams, GetTopInteractedTagsParams } from "./shared.types";
+import {
+  GetAllTagsParams,
+  GetQuestionsByTagIdParams,
+  GetTopInteractedTagsParams,
+} from "./shared.types";
 import Tag, { ITag } from "@/database/tag.model";
 import Question from "@/database/question.model";
 import { FilterQuery } from "mongoose";
@@ -15,12 +19,15 @@ export async function getTopInteractedTags(params: GetTopInteractedTagsParams) {
 
     const user = await User.findById(userId);
 
-    if(!user) throw new Error("User not found");
+    if (!user) throw new Error("User not found");
 
     // Find interactions for the user and group by tags...
     // Interaction...
 
-    return [ {_id: '1', name: 'tag'}, {_id: '2', name: 'tag2'}]
+    return [
+      { _id: "1", name: "tag" },
+      { _id: "2", name: "tag2" },
+    ];
   } catch (error) {
     console.log(error);
     throw error;
@@ -36,26 +43,26 @@ export async function getAllTags(params: GetAllTagsParams) {
 
     const query: FilterQuery<typeof Tag> = {};
 
-    if(searchQuery) {
-      query.$or = [{name: { $regex: new RegExp(searchQuery, 'i')}}]
+    if (searchQuery) {
+      query.$or = [{ name: { $regex: new RegExp(searchQuery, "i") } }];
     }
 
     let sortOptions = {};
 
     switch (filter) {
       case "popular":
-        sortOptions = { questions: -1 }
+        sortOptions = { questions: -1 };
         break;
       case "recent":
-        sortOptions = { createdAt: -1 }
+        sortOptions = { createdAt: -1 };
         break;
       case "name":
-        sortOptions = { name: 1 }
+        sortOptions = { name: 1 };
         break;
       case "old":
-        sortOptions = { createdAt: 1 }
+        sortOptions = { createdAt: 1 };
         break;
-    
+
       default:
         break;
     }
@@ -67,9 +74,9 @@ export async function getAllTags(params: GetAllTagsParams) {
       .skip(skipAmount)
       .limit(pageSize);
 
-      const isNext = totalTags > skipAmount + tags.length;
+    const isNext = totalTags > skipAmount + tags.length;
 
-    return { tags, isNext }
+    return { tags, isNext };
   } catch (error) {
     console.log(error);
     throw error;
@@ -83,35 +90,41 @@ export async function getQuestionsByTagId(params: GetQuestionsByTagIdParams) {
     const { tagId, page = 1, pageSize = 10, searchQuery } = params;
     const skipAmount = (page - 1) * pageSize;
 
-    const tagFilter: FilterQuery<ITag> = { _id: tagId};
+    const tagFilter: FilterQuery<ITag> = { _id: tagId };
 
-    const tag = await Tag.findOne(tagFilter).populate({
-      path: 'questions',
+    const tag = await Tag.findOne(tagFilter);
+
+    // find questions with tagId before populating
+    const allTagQuestions = tag.questions.length;
+
+    await tag.populate({
+      path: "questions",
       model: Question,
       match: searchQuery
-        ? { title: { $regex: searchQuery, $options: 'i' }}
+        ? { title: { $regex: searchQuery, $options: "i" } }
         : {},
       options: {
         sort: { createdAt: -1 },
         skip: skipAmount,
-        limit: pageSize + 1 // +1 to check if there is next page
+        limit: pageSize,
       },
       populate: [
-        { path: 'tags', model: Tag, select: "_id name" },
-        { path: 'author', model: User, select: '_id clerkId name picture'}
-      ]
-    })
+        { path: "tags", model: Tag, select: "_id name" },
+        { path: "author", model: User, select: "_id clerkId name picture" },
+      ],
+    });
 
-    if(!tag) {
-      throw new Error('Tag not found');
+    if (!tag) {
+      throw new Error("Tag not found");
     }
 
-    const isNext = tag.questions.length > pageSize;
-    
     const questions = tag.questions;
 
-    return { tagTitle: tag.name, questions, isNext };
+    // find questions with tagId after populating (current page questions)
+    const currenTagQuestions = questions.length;
+    const isNext = allTagQuestions > skipAmount + currenTagQuestions;
 
+    return { tagTitle: tag.name, questions, isNext };
   } catch (error) {
     console.log(error);
     throw error;
@@ -123,10 +136,10 @@ export async function getTopPopularTags() {
     connectToDatabase();
 
     const popularTags = await Tag.aggregate([
-      { $project: { name: 1, numberOfQuestions: { $size: "$questions" }}},
-      { $sort: { numberOfQuestions: -1 }}, 
-      { $limit: 5 }
-    ])
+      { $project: { name: 1, numberOfQuestions: { $size: "$questions" } } },
+      { $sort: { numberOfQuestions: -1 } },
+      { $limit: 5 },
+    ]);
 
     return popularTags;
   } catch (error) {

--- a/lib/actions/user.action.ts
+++ b/lib/actions/user.action.ts
@@ -1,9 +1,18 @@
-"use server"
+"use server";
 
 import { FilterQuery } from "mongoose";
 import User from "@/database/user.model";
-import { connectToDatabase } from "../mongoose"
-import { CreateUserParams, DeleteUserParams, GetAllUsersParams, GetSavedQuestionsParams, GetUserByIdParams, GetUserStatsParams, ToggleSaveQuestionParams, UpdateUserParams } from "./shared.types";
+import { connectToDatabase } from "../mongoose";
+import {
+  CreateUserParams,
+  DeleteUserParams,
+  GetAllUsersParams,
+  GetSavedQuestionsParams,
+  GetUserByIdParams,
+  GetUserStatsParams,
+  ToggleSaveQuestionParams,
+  UpdateUserParams,
+} from "./shared.types";
 import { revalidatePath } from "next/cache";
 import Question from "@/database/question.model";
 import Tag from "@/database/tag.model";
@@ -62,8 +71,8 @@ export async function deleteUser(params: DeleteUserParams) {
 
     const user = await User.findOneAndDelete({ clerkId });
 
-    if(!user) {
-      throw new Error('User not found');
+    if (!user) {
+      throw new Error("User not found");
     }
 
     // Delete user from database
@@ -95,26 +104,26 @@ export async function getAllUsers(params: GetAllUsersParams) {
 
     const query: FilterQuery<typeof User> = {};
 
-    if(searchQuery) {
+    if (searchQuery) {
       query.$or = [
-        { name: { $regex: new RegExp(searchQuery, 'i') }},
-        { username: { $regex: new RegExp(searchQuery, 'i') }},
-      ]
+        { name: { $regex: new RegExp(searchQuery, "i") } },
+        { username: { $regex: new RegExp(searchQuery, "i") } },
+      ];
     }
 
     let sortOptions = {};
 
     switch (filter) {
       case "new_users":
-        sortOptions = { joinedAt: -1 }
+        sortOptions = { joinedAt: -1 };
         break;
       case "old_users":
-        sortOptions = { joinedAt: 1 }
+        sortOptions = { joinedAt: 1 };
         break;
       case "top_contributors":
-        sortOptions = { reputation: -1 }
+        sortOptions = { reputation: -1 };
         break;
-    
+
       default:
         break;
     }
@@ -122,7 +131,7 @@ export async function getAllUsers(params: GetAllUsersParams) {
     const users = await User.find(query)
       .sort(sortOptions)
       .skip(skipAmount)
-      .limit(pageSize)
+      .limit(pageSize);
 
     const totalUsers = await User.countDocuments(query);
     const isNext = totalUsers > skipAmount + users.length;
@@ -142,27 +151,29 @@ export async function toggleSaveQuestion(params: ToggleSaveQuestionParams) {
 
     const user = await User.findById(userId);
 
-    if(!user) {
-      throw new Error('User not found');
+    if (!user) {
+      throw new Error("User not found");
     }
 
     const isQuestionSaved = user.saved.includes(questionId);
 
-    if(isQuestionSaved) {
+    if (isQuestionSaved) {
       // remove question from saved
-      await User.findByIdAndUpdate(userId, 
-        { $pull: { saved: questionId }},
+      await User.findByIdAndUpdate(
+        userId,
+        { $pull: { saved: questionId } },
         { new: true }
-      )
+      );
     } else {
       // add question to saved
-      await User.findByIdAndUpdate(userId, 
-        { $addToSet: { saved: questionId }},
+      await User.findByIdAndUpdate(
+        userId,
+        { $addToSet: { saved: questionId } },
         { new: true }
-      )
+      );
     }
 
-    revalidatePath(path)
+    revalidatePath(path);
   } catch (error) {
     console.log(error);
     throw error;
@@ -176,57 +187,62 @@ export async function getSavedQuestions(params: GetSavedQuestionsParams) {
     const { clerkId, searchQuery, filter, page = 1, pageSize = 20 } = params;
 
     const skipAmount = (page - 1) * pageSize;
-    
+
     const query: FilterQuery<typeof Question> = searchQuery
-      ? { title: { $regex: new RegExp(searchQuery, 'i') } }
-      : { };
+      ? { title: { $regex: new RegExp(searchQuery, "i") } }
+      : {};
 
-      let sortOptions = {};
+    let sortOptions = {};
 
-      switch (filter) {
-        case "most_recent":
-          sortOptions = { createdAt: -1 }
-          break;
-        case "oldest":
-          sortOptions = { createdAt: 1 }
-          break;
-        case "most_voted":
-          sortOptions = { upvotes: -1 }
-          break;
-        case "most_viewed":
-          sortOptions = { views: -1 }
-          break;
-        case "most_answered":
-          sortOptions = { answers: -1 }
-          break;
-      
-        default:
-          break;
-      }
+    switch (filter) {
+      case "most_recent":
+        sortOptions = { createdAt: -1 };
+        break;
+      case "oldest":
+        sortOptions = { createdAt: 1 };
+        break;
+      case "most_voted":
+        sortOptions = { upvotes: -1 };
+        break;
+      case "most_viewed":
+        sortOptions = { views: -1 };
+        break;
+      case "most_answered":
+        sortOptions = { answers: -1 };
+        break;
 
-    const user = await User
-    .findOne({ clerkId })
-    .populate({
-      path: 'saved',
+      default:
+        break;
+    }
+
+    const user = await User.findOne({ clerkId });
+
+    // Find total saved questions without populating
+    const allUserQuestions = user.saved.length;
+
+    // Populate saved questions
+    await user.populate({
+      path: "saved",
       match: query,
       options: {
         sort: sortOptions,
         skip: skipAmount,
-        limit: pageSize + 1,
+        limit: pageSize,
       },
       populate: [
-        { path: 'tags', model: Tag, select: "_id name" },
-        { path: 'author', model: User, select: '_id clerkId name picture'}
-      ]
-    })
+        { path: "tags", model: Tag, select: "_id name" },
+        { path: "author", model: User, select: "_id clerkId name picture" },
+      ],
+    });
 
-    const isNext = user.saved.length > pageSize;
-    
-    if(!user) {
-      throw new Error('User not found');
+    if (!user) {
+      throw new Error("User not found");
     }
 
     const savedQuestions = user.saved;
+    // find total saved questions after populating (current page questions)
+    const currentSavedQuestions = savedQuestions.length;
+    const isNext = allUserQuestions > skipAmount + currentSavedQuestions;
 
     return { questions: savedQuestions, isNext };
   } catch (error) {
@@ -243,18 +259,18 @@ export async function getUserInfo(params: GetUserByIdParams) {
 
     const user = await User.findOne({ clerkId: userId });
 
-    if(!user) {
-      throw new Error('User not found');
+    if (!user) {
+      throw new Error("User not found");
     }
 
-    const totalQuestions = await Question.countDocuments({ author: user._id })
+    const totalQuestions = await Question.countDocuments({ author: user._id });
     const totalAnswers = await Answer.countDocuments({ author: user._id });
 
     return {
       user,
       totalQuestions,
-      totalAnswers
-    }    
+      totalAnswers,
+    };
   } catch (error) {
     console.log(error);
     throw error;
@@ -269,16 +285,16 @@ export async function getUserQuestions(params: GetUserStatsParams) {
 
     const skipAmount = (page - 1) * pageSize;
 
-    const totalQuestions = await Question.countDocuments({ author: userId})
+    const totalQuestions = await Question.countDocuments({ author: userId });
 
     const userQuestions = await Question.find({ author: userId })
       .sort({ views: -1, upvotes: -1 })
       .skip(skipAmount)
       .limit(pageSize)
-      .populate('tags', '_id name')
-      .populate('author', '_id clerkId name picture')
+      .populate("tags", "_id name")
+      .populate("author", "_id clerkId name picture");
 
-      const isNextQuestions = totalQuestions > skipAmount + userQuestions.length;
+    const isNextQuestions = totalQuestions > skipAmount + userQuestions.length;
 
     return { totalQuestions, questions: userQuestions, isNextQuestions };
   } catch (error) {
@@ -295,17 +311,17 @@ export async function getUserAnswers(params: GetUserStatsParams) {
 
     const skipAmount = (page - 1) * pageSize;
 
-    const totalAnswers = await Answer.countDocuments({ author: userId})
+    const totalAnswers = await Answer.countDocuments({ author: userId });
 
     const userAnswers = await Answer.find({ author: userId })
       .sort({ upvotes: -1 })
       .skip(skipAmount)
       .limit(pageSize)
-      .populate('question', '_id title')
-      .populate('author', '_id clerkId name picture')
+      .populate("question", "_id title")
+      .populate("author", "_id clerkId name picture");
 
-      const isNextAnswer = totalAnswers > skipAmount + userAnswers.length;
-      
+    const isNextAnswer = totalAnswers > skipAmount + userAnswers.length;
+
     return { totalAnswers, answers: userAnswers, isNextAnswer };
   } catch (error) {
     console.log(error);


### PR DESCRIPTION
The original getQuestionsByTagId function had an issue with pagination due to calculating the total number of questions
Which we calculate before the populate process so when we get the length of saved question 
we get it with these options :

` options: {
        sort: { createdAt: -1 },
        skip: skipAmount,
        limit: pageSize + 1,
},`

This is not what we want because here we are applying the limit to the question so we are not able to get the total number

Another problem is we use pageSize + 1 and this the problem 
i will explain why
look at these two line 
const skipAmount = (page - 1) * pageSize;
` options: {
        sort: { createdAt: -1 },
        skip: skipAmount,
        limit: pageSize + 1,
},`

when we are in page 1 => we will show 11 Questions  and skip 0
page 2 => also show 11 question but skip 10 question so we sill show the last question in 
the first page 

The updated version addresses this by:

Finding the Tag First:

It fetches the tag using Tag.findOne(tagFilter). This ensures the tag exists before proceeding.
Separate Population and Length Calculation:

Population: It populates the questions field of the tag with filtering, sorting, skipping, and limiting options. This ensures you get only the relevant questions for the current page.
Length Calculation After Population: After population, it calculates the actual number of questions in the current page (currenTagQuestions) using tag.questions.length.
Correct isNext Calculation:

It determines whether there's a next page by comparing allTagQuestions (total number of questions) with the sum of skipAmount (number of questions skipped) and currenTagQuestions (number of questions retrieved this time). This ensures accurate pagination logic.

and the same in getSavedQuestions function