### PR TITLE
fix: return user tags interactions

### DIFF
--- a/lib/actions/tag.actions.ts
+++ b/lib/actions/tag.actions.ts
@@ -1,11 +1,16 @@
-"use server"
+"use server";
 
 import User from "@/database/user.model";
 import { connectToDatabase } from "../mongoose";
-import { GetAllTagsParams, GetQuestionsByTagIdParams, GetTopInteractedTagsParams } from "./shared.types";
+import {
+  GetAllTagsParams,
+  GetQuestionsByTagIdParams,
+  GetTopInteractedTagsParams,
+} from "./shared.types";
 import Tag, { ITag } from "@/database/tag.model";
 import Question from "@/database/question.model";
 import { FilterQuery } from "mongoose";
+import Interaction from "@/database/interaction.model";
 
 export async function getTopInteractedTags(params: GetTopInteractedTagsParams) {
   try {
@@ -15,12 +20,18 @@ export async function getTopInteractedTags(params: GetTopInteractedTagsParams) {
 
     const user = await User.findById(userId);
 
-    if(!user) throw new Error("User not found");
+    if (!user) throw new Error("User not found");
 
-    // Find interactions for the user and group by tags...
-    // Interaction...
+    // Find the user's interactions where actions equal "ask_question" or "answer" and return tags name without duplicates
+    const userInteractions = await Interaction.find({
+      user: user._id,
+      action: { $in: ["ask_question", "answer"] },
+    }).distinct("tags");
 
-    return [ {_id: '1', name: 'tag'}, {_id: '2', name: 'tag2'}]
+    // Extract tags from user's interactions limited to 5 tags
+    const tags = await Tag.find({ _id: { $in: userInteractions } }).limit(5);
+    // return list of tags
+    return tags;
   } catch (error) {
     console.log(error);
     throw error;
@@ -36,26 +47,26 @@ export async function getAllTags(params: GetAllTagsParams) {
 
     const query: FilterQuery<typeof Tag> = {};
 
-    if(searchQuery) {
-      query.$or = [{name: { $regex: new RegExp(searchQuery, 'i')}}]
+    if (searchQuery) {
+      query.$or = [{ name: { $regex: new RegExp(searchQuery, "i") } }];
     }
 
     let sortOptions = {};
 
     switch (filter) {
       case "popular":
-        sortOptions = { questions: -1 }
+        sortOptions = { questions: -1 };
         break;
       case "recent":
-        sortOptions = { createdAt: -1 }
+        sortOptions = { createdAt: -1 };
         break;
       case "name":
-        sortOptions = { name: 1 }
+        sortOptions = { name: 1 };
         break;
       case "old":
-        sortOptions = { createdAt: 1 }
+        sortOptions = { createdAt: 1 };
         break;
-    
+
       default:
         break;
     }
@@ -67,9 +78,9 @@ export async function getAllTags(params: GetAllTagsParams) {
       .skip(skipAmount)
       .limit(pageSize);
 
-      const isNext = totalTags > skipAmount + tags.length;
+    const isNext = totalTags > skipAmount + tags.length;
 
-    return { tags, isNext }
+    return { tags, isNext };
   } catch (error) {
     console.log(error);
     throw error;
@@ -83,35 +94,34 @@ export async function getQuestionsByTagId(params: GetQuestionsByTagIdParams) {
     const { tagId, page = 1, pageSize = 10, searchQuery } = params;
     const skipAmount = (page - 1) * pageSize;
 
-    const tagFilter: FilterQuery<ITag> = { _id: tagId};
+    const tagFilter: FilterQuery<ITag> = { _id: tagId };
 
     const tag = await Tag.findOne(tagFilter).populate({
-      path: 'questions',
+      path: "questions",
       model: Question,
       match: searchQuery
-        ? { title: { $regex: searchQuery, $options: 'i' }}
+        ? { title: { $regex: searchQuery, $options: "i" } }
         : {},
       options: {
         sort: { createdAt: -1 },
         skip: skipAmount,
-        limit: pageSize + 1 // +1 to check if there is next page
+        limit: pageSize + 1, // +1 to check if there is next page
       },
       populate: [
-        { path: 'tags', model: Tag, select: "_id name" },
-        { path: 'author', model: User, select: '_id clerkId name picture'}
-      ]
-    })
+        { path: "tags", model: Tag, select: "_id name" },
+        { path: "author", model: User, select: "_id clerkId name picture" },
+      ],
+    });
 
-    if(!tag) {
-      throw new Error('Tag not found');
+    if (!tag) {
+      throw new Error("Tag not found");
     }
 
     const isNext = tag.questions.length > pageSize;
-    
+
     const questions = tag.questions;
 
     return { tagTitle: tag.name, questions, isNext };
-
   } catch (error) {
     console.log(error);
     throw error;
@@ -123,10 +133,10 @@ export async function getTopPopularTags() {
     connectToDatabase();
 
     const popularTags = await Tag.aggregate([
-      { $project: { name: 1, numberOfQuestions: { $size: "$questions" }}},
-      { $sort: { numberOfQuestions: -1 }}, 
-      { $limit: 5 }
-    ])
+      { $project: { name: 1, numberOfQuestions: { $size: "$questions" } } },
+      { $sort: { numberOfQuestions: -1 } },
+      { $limit: 5 },
+    ]);
 
     return popularTags;
   } catch (error) {


### PR DESCRIPTION
Remove Static return list and implement dynamic user tags interactions

Static Data 
`
return [ {_id: '1', name: 'tag'}, {_id: '2', name: 'tag2'}]
`
replace with

```

    // Find the user's interactions where actions equal "ask_question" or "answer" and return tags name without duplicates
    const userInteractions = await Interaction.find({
      user: user._id,
      action: { $in: ["ask_question", "answer"] },
    }).distinct("tags");

    // Extract tags from user's interactions limited to 5 tags
    const tags = await Tag.find({ _id: { $in: userInteractions } }).limit(5);
    // return list of tags
    return tags;

```