### PR TITLE
fix: handle invalid regular expression error in search query

### DIFF
--- a/lib/actions/question.action.ts
+++ b/lib/actions/question.action.ts
@@ -22,9 +22,10 @@ export async function getQuestions(params: GetQuestionsParams) {
     const query: FilterQuery<typeof Question> = {};
 
     if(searchQuery) {
+      const escapedSearchQuery = searchQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
       query.$or = [
-        { title: { $regex: new RegExp(searchQuery, "i")}},
-        { content: { $regex: new RegExp(searchQuery, "i")}},
+        { title: { $regex: new RegExp(escapedSearchQuery, "i")}},
+        { content: { $regex: new RegExp(escapedSearchQuery, "i")}},
       ]
     }
 

--- a/lib/actions/tag.actions.ts
+++ b/lib/actions/tag.actions.ts
@@ -37,7 +37,8 @@ export async function getAllTags(params: GetAllTagsParams) {
     const query: FilterQuery<typeof Tag> = {};
 
     if(searchQuery) {
-      query.$or = [{name: { $regex: new RegExp(searchQuery, 'i')}}]
+      const escapedSearchQuery = searchQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      query.$or = [{name: { $regex: new RegExp(escapedSearchQuery, 'i')}}]
     }
 
     let sortOptions = {};

--- a/lib/actions/user.action.ts
+++ b/lib/actions/user.action.ts
@@ -98,9 +98,10 @@ export async function getAllUsers(params: GetAllUsersParams) {
     const query: FilterQuery<typeof User> = {};
 
     if(searchQuery) {
+      const escapedSearchQuery = searchQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
       query.$or = [
-        { name: { $regex: new RegExp(searchQuery, 'i') }},
-        { username: { $regex: new RegExp(searchQuery, 'i') }},
+        { name: { $regex: new RegExp(escapedSearchQuery, 'i') }},
+        { username: { $regex: new RegExp(escapedSearchQuery, 'i') }},
       ]
     }
 


### PR DESCRIPTION
- Escape special characters in the search query to prevent invalid regular expression errors.
- Ensure search queries are safely used in new RegExp().

Fixes the unhandled runtime error: "Invalid regular expression: /\/i: \ at end of pattern".