### PR TITLE
Fix profile link to use author.clerkId instead of author._id

### DIFF
--- a/components/cards/QuestionCard.tsx
+++ b/components/cards/QuestionCard.tsx
@@ -72,7 +72,7 @@ const QuestionCard = ({
             alt="user"
             value={author.name}
             title={` - asked ${getTimestamp(createdAt)}`}
-            href={`/profile/${author._id}`}
+            href={`/profile/${author.clerkId}`}
             isAuthor
             textStyles="body-medium text-dark400_light700"
           />


### PR DESCRIPTION
This PR fixes the profile link to correctly use `author.clerkId` instead of `author._id`. This ensures that the correct user profile is linked. Otherwise, when author name displayed at home page is clicked, it gives an error instead of taking to profile page. 
