### PR TITLE
fix: field-name typos and wrong vote flag in search and voting

### DIFF
--- a/components/shared/Votes.tsx
+++ b/components/shared/Votes.tsx
@@ -100,8 +100,8 @@ const Votes = ({
       }
 
       return toast({
-        title: `Downvote ${!hasupVoted ? 'Successful' : 'Removed'}`,
-        variant: !hasupVoted ? 'default' : 'destructive'
+        title: `Downvote ${!hasdownVoted ? 'Successful' : 'Removed'}`,
+        variant: !hasdownVoted ? 'default' : 'destructive'
       })
       
     }

--- a/lib/actions/answer.action.ts
+++ b/lib/actions/answer.action.ts
@@ -136,7 +136,7 @@ export async function downvoteAnswer(params: AnswerVoteParams) {
     let updateQuery = {};
 
     if(hasdownVoted) {
-      updateQuery = { $pull: { downvote: userId }}
+      updateQuery = { $pull: { downvotes: userId }}
     } else if (hasupVoted) {
       updateQuery = { 
         $pull: { upvotes: userId },

--- a/lib/actions/general.action.ts
+++ b/lib/actions/general.action.ts
@@ -42,7 +42,7 @@ export async function globalSearch(params: SearchParams) {
               : item[searchField],
               type,
               id: type === 'user'
-                ? item.clerkid
+                ? item.clerkId
                 : type==='answer'
                   ? item.question 
                   : item._id


### PR DESCRIPTION
## Summary

While going through the project I ran into a few small but real bugs in the search and voting flows. This PR fixes three of them. All are one-line typos that cause silent wrong behavior, and each is verified against the corresponding Mongoose schema and the matching correct code elsewhere in the repo.

## Fixes

**1. Broken profile links in global search**
`lib/actions/general.action.ts` — in the "search across everything" branch, user results were built with `item.clerkid`, but the `User` schema field is `clerkId` (camelCase). The result `id` came out as `undefined`, so clicking a user in the global search dropdown went to `/profile/undefined`. The type-filtered branch a few lines below already uses `clerkId`.

**2. Answer downvote couldn't be removed**
`lib/actions/answer.action.ts` — `downvoteAnswer` pulled from `downvote`, but the `Answer` schema field is `downvotes` (plural). Removing a downvote pulled from a field that doesn't exist, so the downvote was never actually removed. `question.action.ts` already does this correctly with `downvotes`.

**3. Wrong toast on answer/question downvote**
`components/shared/Votes.tsx` — the downvote toast checked `!hasupVoted` (copy-pasted from the upvote handler) instead of `!hasdownVoted`, so the message and variant ("Successful" / "Removed", default / destructive) were wrong when downvoting.

## Testing

- `npx tsc --noEmit` passes with no errors.
- Each change matches the field name in the relevant schema and mirrors the already-correct usage elsewhere in the codebase.

Net diff is 4 lines across 3 files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected downvote notifications so they now show the right success/removal message and style after voting.
  * Fixed downvote removal so existing downvotes are properly cleared in vote counts.
  * Improved global search so user results display correctly in cross-app searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->