### PR TITLE
fix: prevent ThemeProvider effect from retriggering itself (closes #32)

### DIFF
--- a/components/shared/navbar/Theme.tsx
+++ b/components/shared/navbar/Theme.tsx
@@ -42,11 +42,15 @@ const Theme = () => {
               key={item.value}
               className='flex items-center gap-4 px-2.5 py-2 dark:focus:bg-dark-400'
               onClick={() => {
-                setMode(item.value);
-                if (item.value !== "system") {
-                  localStorage.theme = item.value;
-                } else {
+                if (item.value === "system") {
                   localStorage.removeItem("theme");
+                  const prefersDark = window.matchMedia(
+                    "(prefers-color-scheme: dark)"
+                  ).matches;
+                  setMode(prefersDark ? "dark" : "light");
+                } else {
+                  localStorage.theme = item.value;
+                  setMode(item.value);
                 }
               }}
             >

--- a/context/ThemeProvider.tsx
+++ b/context/ThemeProvider.tsx
@@ -12,24 +12,27 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [mode, setMode] = useState('');
 
-  const handleThemeChange = () => {
-    if(
-      localStorage.theme === 'dark' || 
-      (!("theme" in localStorage) && 
-      window.matchMedia("(prefers-color-scheme: dark)").matches)
-    ) {
-      setMode('dark');
-      document.documentElement.classList.add('dark');
-    } else {
-      setMode('light');
-      document.documentElement.classList.remove('dark');
-    }
-  }
-
+  // Resolve the saved preference (or the OS setting) to a concrete theme,
+  // once, on mount. `mode` is always kept as 'light' | 'dark' so consumers
+  // can rely on it directly.
   useEffect(() => {
-    handleThemeChange();
+    const prefersDark =
+      localStorage.theme === 'dark' ||
+      (!("theme" in localStorage) &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches);
+
+    setMode(prefersDark ? 'dark' : 'light');
+  }, [])
+
+  // Apply the theme to the DOM whenever it changes. This effect only reads
+  // `mode` and writes a class — it never calls setMode, so it cannot
+  // retrigger itself (the "Maximum update depth exceeded" loop in #32).
+  useEffect(() => {
+    if (!mode) return;
+
+    document.documentElement.classList.toggle('dark', mode === 'dark');
   }, [mode])
-  
+
   return (
     <ThemeContext.Provider value={{ mode, setMode }}>
       {children}


### PR DESCRIPTION
Closes #32

## Problem

`ThemeProvider` had a `useEffect` that depended on `mode` and, inside it, called `setMode` again. An effect that both reads and writes the same state it depends on is the classic cause of React's **"Maximum update depth exceeded"** error: setting the state re-runs the effect, which sets the state, which re-runs the effect, and so on.

In the current code the loop happened to be masked by React's same-value `setState` bailout, but the structure is fragile — any tweak to the resolve logic (for example, toggling `mode` instead of reading from storage) brings the infinite loop straight back, which is exactly what #32 reports.

## Fix

Make the data flow one-directional so the loop is structurally impossible:

- **`context/ThemeProvider.tsx`**
  - One effect resolves the saved preference / OS setting to a concrete theme **once on mount** and sets `mode`.
  - A second effect **only applies** the `dark` class to `<html>` based on `mode`. It reads `mode` and writes to the DOM — it never calls `setMode`, so it can't retrigger itself.
- **`components/shared/navbar/Theme.tsx`**
  - The "System" option now resolves to `dark`/`light` (via `prefers-color-scheme`) at click time before calling `setMode`.

This keeps `mode` always `'light' | 'dark'`, so every existing consumer that checks `mode === 'dark'` / `mode === 'light'` (the navbar icon and the TinyMCE editor skin in `Question.tsx` / `Answer.tsx`) keeps working unchanged. No user-facing behavior changes — light, dark, and system selection all behave as before.

## Testing

- `npx tsc --noEmit` passes with no errors.
- Verified that switching between Light / Dark / System applies the correct class and the navbar icon and editor skins stay in sync.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme switching so selecting **System** now correctly follows your device’s light/dark preference.
  * Fixed theme persistence so chosen themes are saved consistently and restored on return visits.
  * Made theme initialization more reliable on page load, reducing flashes or mismatches between the UI and system settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->